### PR TITLE
added test-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+#pycharm
+.idea
+
+#.json .csv
+users.json
+books.csv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/result.json
+++ b/result.json
@@ -1,0 +1,1486 @@
+[
+    {
+        "name": "Lolita Lynn",
+        "gender": "female",
+        "address": "389 Neptune Avenue, Belfair, Iowa, 6116",
+        "age": 34,
+        "books": [
+            {
+                "Title": "Fundamentals of Wavelets",
+                "Author": "Goswami, Jaideva",
+                "Genre": "signal_processing",
+                "Pages": "228"
+            },
+            {
+                "Title": "Complete Sherlock Holmes, The - Vol I",
+                "Author": "Doyle, Arthur Conan",
+                "Genre": "fiction",
+                "Pages": "176"
+            },
+            {
+                "Title": "Econometric Analysis",
+                "Author": "Greene, W. H.",
+                "Genre": "economics",
+                "Pages": "242"
+            },
+            {
+                "Title": "O Jerusalem!",
+                "Author": "Lapierre, Dominique",
+                "Genre": "history",
+                "Pages": "217"
+            },
+            {
+                "Title": "Selected Short Stories",
+                "Author": "",
+                "Genre": "fiction",
+                "Pages": "215"
+            },
+            {
+                "Title": "Batman Earth One",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "265"
+            },
+            {
+                "Title": "Batatyachi Chal",
+                "Author": "Deshpande P L",
+                "Genre": "fiction",
+                "Pages": "200"
+            },
+            {
+                "Title": "Attorney, The",
+                "Author": "",
+                "Genre": "fiction",
+                "Pages": "170"
+            }
+        ]
+    },
+    {
+        "name": "Tonia Hurst",
+        "gender": "female",
+        "address": "917 Terrace Place, Urbana, Idaho, 684",
+        "age": 31,
+        "books": [
+            {
+                "Title": "Data Smart",
+                "Author": "Foreman, John",
+                "Genre": "data_science",
+                "Pages": "235"
+            },
+            {
+                "Title": "Complete Sherlock Holmes, The - Vol II",
+                "Author": "Doyle, Arthur Conan",
+                "Genre": "fiction",
+                "Pages": "176"
+            },
+            {
+                "Title": "Learning OpenCV",
+                "Author": "Bradsky, Gary",
+                "Genre": "data_science",
+                "Pages": "232"
+            },
+            {
+                "Title": "City of Joy, The",
+                "Author": "Lapierre, Dominique",
+                "Genre": "fiction",
+                "Pages": "177"
+            },
+            {
+                "Title": "Rationality & Freedom",
+                "Author": "Sen, Amartya",
+                "Genre": "economics",
+                "Pages": "213"
+            },
+            {
+                "Title": "Crisis on Infinite Earths",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "258"
+            },
+            {
+                "Title": "Hafasavnuk",
+                "Author": "Deshpande P L",
+                "Genre": "fiction",
+                "Pages": "211"
+            },
+            {
+                "Title": "Prince, The",
+                "Author": "Machiavelli",
+                "Genre": "philosophy",
+                "Pages": "173"
+            }
+        ]
+    },
+    {
+        "name": "Brooks Bright",
+        "gender": "male",
+        "address": "901 Mermaid Avenue, Wyoming, Marshall Islands, 8506",
+        "age": 39,
+        "books": [
+            {
+                "Title": "God Created the Integers",
+                "Author": "Hawking, Stephen",
+                "Genre": "mathematics",
+                "Pages": "197"
+            },
+            {
+                "Title": "Wealth of Nations, The",
+                "Author": "Smith, Adam",
+                "Genre": "economics",
+                "Pages": "175"
+            },
+            {
+                "Title": "Data Structures Using C & C++",
+                "Author": "Tanenbaum, Andrew",
+                "Genre": "computer_science",
+                "Pages": "235"
+            },
+            {
+                "Title": "Freedom at Midnight",
+                "Author": "Lapierre, Dominique",
+                "Genre": "history",
+                "Pages": "167"
+            },
+            {
+                "Title": "Clash of Civilizations and Remaking of the World Order",
+                "Author": "Huntington, Samuel",
+                "Genre": "history",
+                "Pages": "228"
+            },
+            {
+                "Title": "Numbers Behind Numb3rs, The",
+                "Author": "Devlin, Keith",
+                "Genre": "science",
+                "Pages": "202"
+            },
+            {
+                "Title": "Urlasurla",
+                "Author": "Deshpande P L",
+                "Genre": "fiction",
+                "Pages": "211"
+            },
+            {
+                "Title": "Eyeless in Gaza",
+                "Author": "Huxley, Aldous",
+                "Genre": "fiction",
+                "Pages": "180"
+            }
+        ]
+    },
+    {
+        "name": "Kathrine Sharp",
+        "gender": "female",
+        "address": "989 Huron Street, Talpa, Utah, 7018",
+        "age": 40,
+        "books": [
+            {
+                "Title": "Superfreakonomics",
+                "Author": "Dubner, Stephen",
+                "Genre": "economics",
+                "Pages": "179"
+            },
+            {
+                "Title": "Pillars of the Earth, The",
+                "Author": "Follett, Ken",
+                "Genre": "fiction",
+                "Pages": "176"
+            },
+            {
+                "Title": "Computer Vision, A Modern Approach",
+                "Author": "Forsyth, David",
+                "Genre": "data_science",
+                "Pages": "255"
+            },
+            {
+                "Title": "Winter of Our Discontent, The",
+                "Author": "Steinbeck, John",
+                "Genre": "fiction",
+                "Pages": "196"
+            },
+            {
+                "Title": "Uncommon Wisdom",
+                "Author": "Capra, Fritjof",
+                "Genre": "nonfiction",
+                "Pages": "197"
+            },
+            {
+                "Title": "Superman Earth One - 1",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "259"
+            },
+            {
+                "Title": "Pointers in C",
+                "Author": "Kanetkar, Yashwant",
+                "Genre": "computer_science",
+                "Pages": "213"
+            },
+            {
+                "Title": "Tales of Beedle the Bard",
+                "Author": "Rowling, J K",
+                "Genre": "fiction",
+                "Pages": "184"
+            }
+        ]
+    },
+    {
+        "name": "Shawn Harrell",
+        "gender": "female",
+        "address": "534 Hinsdale Street, Albany, Palau, 3291",
+        "age": 34,
+        "books": [
+            {
+                "Title": "Orientalism",
+                "Author": "Said, Edward",
+                "Genre": "history",
+                "Pages": "197"
+            },
+            {
+                "Title": "Tao of Physics, The",
+                "Author": "Capra, Fritjof",
+                "Genre": "science",
+                "Pages": "179"
+            },
+            {
+                "Title": "Principles of Communication Systems",
+                "Author": "Taub, Schilling",
+                "Genre": "computer_science",
+                "Pages": "240"
+            },
+            {
+                "Title": "On Education",
+                "Author": "Russell, Bertrand",
+                "Genre": "philosophy",
+                "Pages": "203"
+            },
+            {
+                "Title": "One",
+                "Author": "Bach, Richard",
+                "Genre": "nonfiction",
+                "Pages": "172"
+            },
+            {
+                "Title": "Superman Earth One - 2",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "258"
+            },
+            {
+                "Title": "Cathedral and the Bazaar, The",
+                "Author": "Raymond, Eric",
+                "Genre": "computer_science",
+                "Pages": "217"
+            },
+            {
+                "Title": "Girl with the Dragon Tattoo",
+                "Author": "Larsson, Steig",
+                "Genre": "fiction",
+                "Pages": "179"
+            }
+        ]
+    },
+    {
+        "name": "Amy Casey",
+        "gender": "female",
+        "address": "589 Townsend Street, Hiseville, Connecticut, 7082",
+        "age": 31,
+        "books": [
+            {
+                "Title": "Nature of Statistical Learning Theory, The",
+                "Author": "Vapnik, Vladimir",
+                "Genre": "data_science",
+                "Pages": "230"
+            },
+            {
+                "Title": "Surely You're Joking Mr Feynman",
+                "Author": "Feynman, Richard",
+                "Genre": "science",
+                "Pages": "198"
+            },
+            {
+                "Title": "Let Us C",
+                "Author": "Kanetkar, Yashwant",
+                "Genre": "computer_science",
+                "Pages": "213"
+            },
+            {
+                "Title": "Free Will",
+                "Author": "Harris, Sam",
+                "Genre": "philosophy",
+                "Pages": "203"
+            },
+            {
+                "Title": "Karl Marx Biography",
+                "Author": "",
+                "Genre": "nonfiction",
+                "Pages": "162"
+            },
+            {
+                "Title": "Justice League: Throne of Atlantis",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "258"
+            },
+            {
+                "Title": "Design with OpAmps",
+                "Author": "Franco, Sergio",
+                "Genre": "computer_science",
+                "Pages": "240"
+            },
+            {
+                "Title": "Girl who kicked the Hornet's Nest",
+                "Author": "Larsson, Steig",
+                "Genre": "fiction",
+                "Pages": "179"
+            }
+        ]
+    },
+    {
+        "name": "Lorena Mejia",
+        "gender": "female",
+        "address": "614 High Street, Blanford, Maryland, 2776",
+        "age": 24,
+        "books": [
+            {
+                "Title": "Integration of the Indian States",
+                "Author": "Menon, V P",
+                "Genre": "history",
+                "Pages": "217"
+            },
+            {
+                "Title": "Farewell to Arms, A",
+                "Author": "Hemingway, Ernest",
+                "Genre": "fiction",
+                "Pages": "179"
+            },
+            {
+                "Title": "Amulet of Samarkand, The",
+                "Author": "Stroud, Jonathan",
+                "Genre": "fiction",
+                "Pages": "179"
+            },
+            {
+                "Title": "Bookless in Baghdad",
+                "Author": "Tharoor, Shashi",
+                "Genre": "nonfiction",
+                "Pages": "206"
+            },
+            {
+                "Title": "To Sir With Love",
+                "Author": "Braithwaite",
+                "Genre": "fiction",
+                "Pages": "197"
+            },
+            {
+                "Title": "Justice League: The Villain's Journey",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "258"
+            },
+            {
+                "Title": "Think Complexity",
+                "Author": "Downey, Allen",
+                "Genre": "data_science",
+                "Pages": "230"
+            },
+            {
+                "Title": "Girl who played with Fire",
+                "Author": "Larsson, Steig",
+                "Genre": "fiction",
+                "Pages": "179"
+            }
+        ]
+    },
+    {
+        "name": "Allyson Wilkins",
+        "gender": "female",
+        "address": "572 Downing Street, Ivanhoe, American Samoa, 8235",
+        "age": 29,
+        "books": [
+            {
+                "Title": "Drunkard's Walk, The",
+                "Author": "Mlodinow, Leonard",
+                "Genre": "science",
+                "Pages": "197"
+            },
+            {
+                "Title": "Veteran, The",
+                "Author": "Forsyth, Frederick",
+                "Genre": "fiction",
+                "Pages": "177"
+            },
+            {
+                "Title": "Crime and Punishment",
+                "Author": "Dostoevsky, Fyodor",
+                "Genre": "fiction",
+                "Pages": "180"
+            },
+            {
+                "Title": "Case of the Lame Canary, The",
+                "Author": "Gardner, Earle Stanley",
+                "Genre": "fiction",
+                "Pages": "179"
+            },
+            {
+                "Title": "Half A Life",
+                "Author": "Naipaul, V S",
+                "Genre": "fiction",
+                "Pages": "196"
+            },
+            {
+                "Title": "Death of Superman, The",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "258"
+            },
+            {
+                "Title": "Devil's Advocate, The",
+                "Author": "West, Morris",
+                "Genre": "fiction",
+                "Pages": "178"
+            },
+            {
+                "Title": "Batman Handbook",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "270"
+            }
+        ]
+    },
+    {
+        "name": "Mays Reed",
+        "gender": "male",
+        "address": "306 Georgia Avenue, Hall, New Mexico, 1402",
+        "age": 38,
+        "books": [
+            {
+                "Title": "Image Processing & Mathematical Morphology",
+                "Author": "Shih, Frank",
+                "Genre": "signal_processing",
+                "Pages": "241"
+            },
+            {
+                "Title": "False Impressions",
+                "Author": "Archer, Jeffery",
+                "Genre": "fiction",
+                "Pages": "177"
+            },
+            {
+                "Title": "Angels & Demons",
+                "Author": "Brown, Dan",
+                "Genre": "fiction",
+                "Pages": "178"
+            },
+            {
+                "Title": "Theory of Everything, The",
+                "Author": "Hawking, Stephen",
+                "Genre": "science",
+                "Pages": "217"
+            },
+            {
+                "Title": "Discovery of India, The",
+                "Author": "Nehru, Jawaharlal",
+                "Genre": "history",
+                "Pages": "230"
+            },
+            {
+                "Title": "History of the DC Universe",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "258"
+            },
+            {
+                "Title": "Ayn Rand Answers",
+                "Author": "Rand, Ayn",
+                "Genre": "philosophy",
+                "Pages": "203"
+            },
+            {
+                "Title": "Murphy's Law",
+                "Author": "",
+                "Genre": "nonfiction",
+                "Pages": "178"
+            }
+        ]
+    },
+    {
+        "name": "Katherine Mayer",
+        "gender": "female",
+        "address": "640 Prescott Place, Curtice, Kansas, 3395",
+        "age": 27,
+        "books": [
+            {
+                "Title": "How to Think Like Sherlock Holmes",
+                "Author": "Konnikova, Maria",
+                "Genre": "psychology",
+                "Pages": "240"
+            },
+            {
+                "Title": "Last Lecture, The",
+                "Author": "Pausch, Randy",
+                "Genre": "nonfiction",
+                "Pages": "197"
+            },
+            {
+                "Title": "Argumentative Indian, The",
+                "Author": "Sen, Amartya",
+                "Genre": "nonfiction",
+                "Pages": "209"
+            },
+            {
+                "Title": "New Markets & Other Essays",
+                "Author": "Drucker, Peter",
+                "Genre": "economics",
+                "Pages": "176"
+            },
+            {
+                "Title": "Apulki",
+                "Author": "Deshpande, P L",
+                "Genre": "nonfiction",
+                "Pages": "211"
+            },
+            {
+                "Title": "Batman: The Long Halloween",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "258"
+            },
+            {
+                "Title": "Philosophy: Who Needs It",
+                "Author": "Rand, Ayn",
+                "Genre": "philosophy",
+                "Pages": "171"
+            },
+            {
+                "Title": "Structure and Randomness",
+                "Author": "Tao, Terence",
+                "Genre": "mathematics",
+                "Pages": "252"
+            }
+        ]
+    },
+    {
+        "name": "Kelly Byers",
+        "gender": "female",
+        "address": "865 Revere Place, Homeland, Arizona, 232",
+        "age": 35,
+        "books": [
+            {
+                "Title": "Data Scientists at Work",
+                "Author": "Sebastian Gutierrez",
+                "Genre": "data_science",
+                "Pages": "230"
+            },
+            {
+                "Title": "Return of the Primitive",
+                "Author": "Rand, Ayn",
+                "Genre": "philosophy",
+                "Pages": "202"
+            },
+            {
+                "Title": "Sea of Poppies",
+                "Author": "Ghosh, Amitav",
+                "Genre": "fiction",
+                "Pages": "197"
+            },
+            {
+                "Title": "Electric Universe",
+                "Author": "Bodanis, David",
+                "Genre": "science",
+                "Pages": "201"
+            },
+            {
+                "Title": "Unpopular Essays",
+                "Author": "Russell, Bertrand",
+                "Genre": "philosophy",
+                "Pages": "198"
+            },
+            {
+                "Title": "Life in Letters, A",
+                "Author": "Steinbeck, John",
+                "Genre": "nonfiction",
+                "Pages": "196"
+            },
+            {
+                "Title": "World's Great Thinkers, The",
+                "Author": "",
+                "Genre": "philosophy",
+                "Pages": "189"
+            },
+            {
+                "Title": "Image Processing with MATLAB",
+                "Author": "Eddins, Steve",
+                "Genre": "signal_processing",
+                "Pages": "241"
+            }
+        ]
+    },
+    {
+        "name": "Schwartz Carey",
+        "gender": "male",
+        "address": "860 Centre Street, Hiwasse, Nevada, 2819",
+        "age": 32,
+        "books": [
+            {
+                "Title": "Slaughterhouse Five",
+                "Author": "Vonnegut, Kurt",
+                "Genre": "fiction",
+                "Pages": "198"
+            },
+            {
+                "Title": "Jurassic Park",
+                "Author": "Crichton, Michael",
+                "Genre": "fiction",
+                "Pages": "174"
+            },
+            {
+                "Title": "Idea of Justice, The",
+                "Author": "Sen, Amartya",
+                "Genre": "nonfiction",
+                "Pages": "212"
+            },
+            {
+                "Title": "Hunchback of Notre Dame, The",
+                "Author": "Hugo, Victor",
+                "Genre": "fiction",
+                "Pages": "175"
+            },
+            {
+                "Title": "Deceiver, The",
+                "Author": "Forsyth, Frederick",
+                "Genre": "fiction",
+                "Pages": "178"
+            },
+            {
+                "Title": "Information, The",
+                "Author": "Gleick, James",
+                "Genre": "science",
+                "Pages": "233"
+            },
+            {
+                "Title": "Data Analysis with Open Source Tools",
+                "Author": "Janert, Phillip",
+                "Genre": "data_science",
+                "Pages": "230"
+            },
+            {
+                "Title": "Animal Farm",
+                "Author": "Orwell, George",
+                "Genre": "fiction",
+                "Pages": "180"
+            }
+        ]
+    },
+    {
+        "name": "Kay Beasley",
+        "gender": "female",
+        "address": "358 Sutton Street, Bellamy, Ohio, 8845",
+        "age": 34,
+        "books": [
+            {
+                "Title": "Birth of a Theorem",
+                "Author": "Villani, Cedric",
+                "Genre": "mathematics",
+                "Pages": "234"
+            },
+            {
+                "Title": "Russian Journal, A",
+                "Author": "Steinbeck, John",
+                "Genre": "nonfiction",
+                "Pages": "196"
+            },
+            {
+                "Title": "Raisin in the Sun, A",
+                "Author": "Hansberry, Lorraine",
+                "Genre": "fiction",
+                "Pages": "175"
+            },
+            {
+                "Title": "Burning Bright",
+                "Author": "Steinbeck, John",
+                "Genre": "fiction",
+                "Pages": "175"
+            },
+            {
+                "Title": "Veil: Secret Wars of the CIA",
+                "Author": "Woodward, Bob",
+                "Genre": "history",
+                "Pages": "171"
+            },
+            {
+                "Title": "Journal of Economics, vol 106 No 3",
+                "Author": "",
+                "Genre": "economics",
+                "Pages": "235"
+            },
+            {
+                "Title": "Broca's Brain",
+                "Author": "Sagan, Carl",
+                "Genre": "science",
+                "Pages": "174"
+            },
+            {
+                "Title": "Idiot, The",
+                "Author": "Dostoevsky, Fyodor",
+                "Genre": "fiction",
+                "Pages": "197"
+            }
+        ]
+    },
+    {
+        "name": "Robbins Gordon",
+        "gender": "male",
+        "address": "610 Langham Street, Boykin, Guam, 6688",
+        "age": 23,
+        "books": [
+            {
+                "Title": "Structure & Interpretation of Computer Programs",
+                "Author": "Sussman, Gerald",
+                "Genre": "computer_science",
+                "Pages": "240"
+            },
+            {
+                "Title": "Tales of Mystery and Imagination",
+                "Author": "Poe, Edgar Allen",
+                "Genre": "fiction",
+                "Pages": "172"
+            },
+            {
+                "Title": "All the President's Men",
+                "Author": "Woodward, Bob",
+                "Genre": "history",
+                "Pages": "177"
+            },
+            {
+                "Title": "Age of Discontuinity, The",
+                "Author": "Drucker, Peter",
+                "Genre": "economics",
+                "Pages": "178"
+            },
+            {
+                "Title": "Char Shabda",
+                "Author": "Deshpande, P L",
+                "Genre": "nonfiction",
+                "Pages": "214"
+            },
+            {
+                "Title": "Elements of Information Theory",
+                "Author": "Thomas, Joy",
+                "Genre": "data_science",
+                "Pages": "229"
+            },
+            {
+                "Title": "Men of Mathematics",
+                "Author": "Bell, E T",
+                "Genre": "mathematics",
+                "Pages": "217"
+            },
+            {
+                "Title": "Christmas Carol, A",
+                "Author": "Dickens, Charles",
+                "Genre": "fiction",
+                "Pages": "196"
+            }
+        ]
+    },
+    {
+        "name": "Hillary Bauer",
+        "gender": "female",
+        "address": "951 Cumberland Street, Alleghenyville, Oregon, 7073",
+        "age": 39,
+        "books": [
+            {
+                "Title": "Age of Wrath, The",
+                "Author": "Eraly, Abraham",
+                "Genre": "history",
+                "Pages": "238"
+            },
+            {
+                "Title": "Freakonomics",
+                "Author": "Dubner, Stephen",
+                "Genre": "economics",
+                "Pages": "197"
+            },
+            {
+                "Title": "Prisoner of Birth, A",
+                "Author": "Archer, Jeffery",
+                "Genre": "fiction",
+                "Pages": "176"
+            },
+            {
+                "Title": "Doctor in the Nude",
+                "Author": "Gordon, Richard",
+                "Genre": "fiction",
+                "Pages": "179"
+            },
+            {
+                "Title": "Rosy is My Relative",
+                "Author": "Durrell, Gerald",
+                "Genre": "fiction",
+                "Pages": "176"
+            },
+            {
+                "Title": "Power Electronics - Rashid",
+                "Author": "Rashid, Muhammad",
+                "Genre": "computer_science",
+                "Pages": "235"
+            },
+            {
+                "Title": "Oxford book of Modern Science Writing",
+                "Author": "Dawkins, Richard",
+                "Genre": "science",
+                "Pages": "240"
+            }
+        ]
+    },
+    {
+        "name": "Ruiz Phelps",
+        "gender": "male",
+        "address": "836 Troutman Street, Harborton, Kentucky, 4030",
+        "age": 36,
+        "books": [
+            {
+                "Title": "Trial, The",
+                "Author": "Kafka, Frank",
+                "Genre": "fiction",
+                "Pages": "198"
+            },
+            {
+                "Title": "Hidden Connections, The",
+                "Author": "Capra, Fritjof",
+                "Genre": "science",
+                "Pages": "197"
+            },
+            {
+                "Title": "Scoop!",
+                "Author": "Nayar, Kuldip",
+                "Genre": "history",
+                "Pages": "216"
+            },
+            {
+                "Title": "Down and Out in Paris & London",
+                "Author": "Orwell, George",
+                "Genre": "nonfiction",
+                "Pages": "179"
+            },
+            {
+                "Title": "Moon and Sixpence, The",
+                "Author": "Maugham, William S",
+                "Genre": "fiction",
+                "Pages": "180"
+            },
+            {
+                "Title": "Power Electronics - Mohan",
+                "Author": "Mohan, Ned",
+                "Genre": "computer_science",
+                "Pages": "237"
+            },
+            {
+                "Title": "Justice, Judiciary and Democracy",
+                "Author": "Ranjan, Sudhanshu",
+                "Genre": "philosophy",
+                "Pages": "224"
+            }
+        ]
+    },
+    {
+        "name": "Carolina Bryant",
+        "gender": "female",
+        "address": "377 Middagh Street, Ellerslie, Nebraska, 2644",
+        "age": 31,
+        "books": [
+            {
+                "Title": "Statistical Decision Theory'",
+                "Author": "Pratt, John",
+                "Genre": "data_science",
+                "Pages": "236"
+            },
+            {
+                "Title": "Story of Philosophy, The",
+                "Author": "Durant, Will",
+                "Genre": "philosophy",
+                "Pages": "170"
+            },
+            {
+                "Title": "Ahe Manohar Tari",
+                "Author": "Deshpande, Sunita",
+                "Genre": "nonfiction",
+                "Pages": "213"
+            },
+            {
+                "Title": "Identity & Violence",
+                "Author": "Sen, Amartya",
+                "Genre": "philosophy",
+                "Pages": "219"
+            },
+            {
+                "Title": "Political Philosophers",
+                "Author": "",
+                "Genre": "philosophy",
+                "Pages": "162"
+            },
+            {
+                "Title": "Neural Networks",
+                "Author": "Haykin, Simon",
+                "Genre": "data_science",
+                "Pages": "240"
+            },
+            {
+                "Title": "Arthashastra, The",
+                "Author": "Kautiyla",
+                "Genre": "philosophy",
+                "Pages": "214"
+            }
+        ]
+    },
+    {
+        "name": "Sosa Lee",
+        "gender": "male",
+        "address": "364 Holly Street, Omar, California, 5140",
+        "age": 31,
+        "books": [
+            {
+                "Title": "Data Mining Handbook",
+                "Author": "Nisbet, Robert",
+                "Genre": "data_science",
+                "Pages": "242"
+            },
+            {
+                "Title": "Asami Asami",
+                "Author": "Deshpande, P L",
+                "Genre": "fiction",
+                "Pages": "205"
+            },
+            {
+                "Title": "Last Mughal, The",
+                "Author": "Dalrymple, William",
+                "Genre": "history",
+                "Pages": "199"
+            },
+            {
+                "Title": "Beyond the Three Seas",
+                "Author": "Dalrymple, William",
+                "Genre": "history",
+                "Pages": "197"
+            },
+            {
+                "Title": "Short History of the World, A",
+                "Author": "Wells, H G",
+                "Genre": "history",
+                "Pages": "197"
+            },
+            {
+                "Title": "Grapes of Wrath, The",
+                "Author": "Steinbeck, John",
+                "Genre": "fiction",
+                "Pages": "196"
+            },
+            {
+                "Title": "We the People",
+                "Author": "Palkhivala",
+                "Genre": "philosophy",
+                "Pages": "216"
+            }
+        ]
+    },
+    {
+        "name": "Lorna Scott",
+        "gender": "female",
+        "address": "878 Marconi Place, Gerton, Alabama, 845",
+        "age": 24,
+        "books": [
+            {
+                "Title": "New Machiavelli, The",
+                "Author": "Wells, H. G.",
+                "Genre": "fiction",
+                "Pages": "180"
+            },
+            {
+                "Title": "Journal of a Novel",
+                "Author": "Steinbeck, John",
+                "Genre": "fiction",
+                "Pages": "196"
+            },
+            {
+                "Title": "Social Choice & Welfare, Vol 39 No. 1",
+                "Author": "Various",
+                "Genre": "economics",
+                "Pages": "235"
+            },
+            {
+                "Title": "World's Greatest Short Stories, The",
+                "Author": "",
+                "Genre": "fiction",
+                "Pages": "217"
+            },
+            {
+                "Title": "Trembling of a Leaf, The",
+                "Author": "Maugham, William S",
+                "Genre": "fiction",
+                "Pages": "205"
+            },
+            {
+                "Title": "Vyakti ani Valli",
+                "Author": "Deshpande, P L",
+                "Genre": "nonfiction",
+                "Pages": "211"
+            },
+            {
+                "Title": "We the Nation",
+                "Author": "Palkhivala",
+                "Genre": "philosophy",
+                "Pages": "216"
+            }
+        ]
+    },
+    {
+        "name": "Bernard Holden",
+        "gender": "male",
+        "address": "674 Pine Street, Conestoga, Mississippi, 4727",
+        "age": 32,
+        "books": [
+            {
+                "Title": "Physics & Philosophy",
+                "Author": "Heisenberg, Werner",
+                "Genre": "science",
+                "Pages": "197"
+            },
+            {
+                "Title": "Once There Was a War",
+                "Author": "Steinbeck, John",
+                "Genre": "nonfiction",
+                "Pages": "196"
+            },
+            {
+                "Title": "Radiowaril Bhashane & Shrutika",
+                "Author": "Deshpande, P L",
+                "Genre": "nonfiction",
+                "Pages": "213"
+            },
+            {
+                "Title": "Talking Straight",
+                "Author": "Iacoca, Lee",
+                "Genre": "nonfiction",
+                "Pages": "175"
+            },
+            {
+                "Title": "Doctor on the Brain",
+                "Author": "Gordon, Richard",
+                "Genre": "fiction",
+                "Pages": "204"
+            },
+            {
+                "Title": "Statistical Learning Theory",
+                "Author": "Vapnik, Vladimir",
+                "Genre": "data_science",
+                "Pages": "228"
+            },
+            {
+                "Title": "Courtroom Genius, The",
+                "Author": "Sorabjee",
+                "Genre": "nonfiction",
+                "Pages": "217"
+            }
+        ]
+    },
+    {
+        "name": "Craft Shields",
+        "gender": "male",
+        "address": "586 Java Street, Catherine, Arkansas, 1445",
+        "age": 31,
+        "books": [
+            {
+                "Title": "Making Software",
+                "Author": "Oram, Andy",
+                "Genre": "computer_science",
+                "Pages": "232"
+            },
+            {
+                "Title": "Moon is Down, The",
+                "Author": "Steinbeck, John",
+                "Genre": "fiction",
+                "Pages": "196"
+            },
+            {
+                "Title": "Gun Gayin Awadi",
+                "Author": "Deshpande, P L",
+                "Genre": "nonfiction",
+                "Pages": "212"
+            },
+            {
+                "Title": "Maugham's Collected Short Stories, Vol 3",
+                "Author": "Maugham, William S",
+                "Genre": "fiction",
+                "Pages": "171"
+            },
+            {
+                "Title": "Simpsons & Their Mathematical Secrets",
+                "Author": "Singh, Simon",
+                "Genre": "science",
+                "Pages": "233"
+            },
+            {
+                "Title": "Empire of the Mughal - The Tainted Throne",
+                "Author": "Rutherford, Alex",
+                "Genre": "history",
+                "Pages": "180"
+            },
+            {
+                "Title": "Dongri to Dubai",
+                "Author": "Zaidi, Hussain",
+                "Genre": "nonfiction",
+                "Pages": "216"
+            }
+        ]
+    },
+    {
+        "name": "Mara English",
+        "gender": "female",
+        "address": "324 Herkimer Court, Boomer, Delaware, 5367",
+        "age": 23,
+        "books": [
+            {
+                "Title": "Analysis, Vol I",
+                "Author": "Tao, Terence",
+                "Genre": "mathematics",
+                "Pages": "248"
+            },
+            {
+                "Title": "Brethren, The",
+                "Author": "Grisham, John",
+                "Genre": "fiction",
+                "Pages": "174"
+            },
+            {
+                "Title": "Aghal Paghal",
+                "Author": "Deshpande, P L",
+                "Genre": "nonfiction",
+                "Pages": "212"
+            },
+            {
+                "Title": "Phantom of Manhattan, The",
+                "Author": "Forsyth, Frederick",
+                "Genre": "fiction",
+                "Pages": "180"
+            },
+            {
+                "Title": "Pattern Classification",
+                "Author": "Duda, Hart",
+                "Genre": "data_science",
+                "Pages": "241"
+            },
+            {
+                "Title": "Empire of the Mughal - Brothers at War",
+                "Author": "Rutherford, Alex",
+                "Genre": "history",
+                "Pages": "180"
+            },
+            {
+                "Title": "History of England, Foundation",
+                "Author": "Ackroyd, Peter",
+                "Genre": "history",
+                "Pages": "197"
+            }
+        ]
+    },
+    {
+        "name": "Fisher Levy",
+        "gender": "male",
+        "address": "540 Adler Place, Hachita, Federated States Of Micronesia, 9894",
+        "age": 30,
+        "books": [
+            {
+                "Title": "Machine Learning for Hackers",
+                "Author": "Conway, Drew",
+                "Genre": "data_science",
+                "Pages": "233"
+            },
+            {
+                "Title": "In a Free State",
+                "Author": "Naipaul, V. S.",
+                "Genre": "fiction",
+                "Pages": "196"
+            },
+            {
+                "Title": "Maqta-e-Ghalib",
+                "Author": "Garg, Sanjay",
+                "Genre": "fiction",
+                "Pages": "221"
+            },
+            {
+                "Title": "Ashenden of The British Agent",
+                "Author": "Maugham, William S",
+                "Genre": "fiction",
+                "Pages": "160"
+            },
+            {
+                "Title": "From Beirut to Jerusalem",
+                "Author": "Friedman, Thomas",
+                "Genre": "history",
+                "Pages": "202"
+            },
+            {
+                "Title": "Empire of the Mughal - Ruler of the World",
+                "Author": "Rutherford, Alex",
+                "Genre": "history",
+                "Pages": "180"
+            },
+            {
+                "Title": "City of Djinns",
+                "Author": "Dalrymple, William",
+                "Genre": "history",
+                "Pages": "198"
+            }
+        ]
+    },
+    {
+        "name": "Cecelia Snyder",
+        "gender": "female",
+        "address": "236 Anchorage Place, Odessa, Michigan, 6314",
+        "age": 25,
+        "books": [
+            {
+                "Title": "Signal and the Noise, The",
+                "Author": "Silver, Nate",
+                "Genre": "data_science",
+                "Pages": "233"
+            },
+            {
+                "Title": "Catch 22",
+                "Author": "Heller, Joseph",
+                "Genre": "fiction",
+                "Pages": "178"
+            },
+            {
+                "Title": "Beyond Degrees",
+                "Author": "",
+                "Genre": "nonfiction",
+                "Pages": "222"
+            },
+            {
+                "Title": "Zen & The Art of Motorcycle Maintenance",
+                "Author": "Pirsig, Robert",
+                "Genre": "philosophy",
+                "Pages": "172"
+            },
+            {
+                "Title": "Code Book, The",
+                "Author": "Singh, Simon",
+                "Genre": "science",
+                "Pages": "197"
+            },
+            {
+                "Title": "Empire of the Mughal - The Serpent's Tooth",
+                "Author": "Rutherford, Alex",
+                "Genre": "history",
+                "Pages": "180"
+            },
+            {
+                "Title": "India's Legal System",
+                "Author": "Nariman",
+                "Genre": "nonfiction",
+                "Pages": "177"
+            }
+        ]
+    },
+    {
+        "name": "Nina Kaufman",
+        "gender": "female",
+        "address": "538 Ashford Street, Boling, West Virginia, 7840",
+        "age": 22,
+        "books": [
+            {
+                "Title": "Python for Data Analysis",
+                "Author": "McKinney, Wes",
+                "Genre": "data_science",
+                "Pages": "233"
+            },
+            {
+                "Title": "Complete Mastermind, The",
+                "Author": "BBC",
+                "Genre": "nonfiction",
+                "Pages": "178"
+            },
+            {
+                "Title": "Manasa",
+                "Author": "Kale, V P",
+                "Genre": "nonfiction",
+                "Pages": "213"
+            },
+            {
+                "Title": "Great War for Civilization, The",
+                "Author": "Fisk, Robert",
+                "Genre": "history",
+                "Pages": "197"
+            },
+            {
+                "Title": "Age of the Warrior, The",
+                "Author": "Fisk, Robert",
+                "Genre": "history",
+                "Pages": "197"
+            },
+            {
+                "Title": "Empire of the Mughal - Raiders from the North",
+                "Author": "Rutherford, Alex",
+                "Genre": "history",
+                "Pages": "180"
+            },
+            {
+                "Title": "More Tears to Cry",
+                "Author": "Sassoon, Jean",
+                "Genre": "fiction",
+                "Pages": "235"
+            }
+        ]
+    },
+    {
+        "name": "Dillard Branch",
+        "gender": "male",
+        "address": "225 Hampton Avenue, Bethany, Pennsylvania, 8056",
+        "age": 37,
+        "books": [
+            {
+                "Title": "Introduction to Algorithms",
+                "Author": "Cormen, Thomas",
+                "Genre": "computer_science",
+                "Pages": "234"
+            },
+            {
+                "Title": "Dylan on Dylan",
+                "Author": "Dylan, Bob",
+                "Genre": "nonfiction",
+                "Pages": "197"
+            },
+            {
+                "Title": "India from Midnight to Milennium",
+                "Author": "Tharoor, Shashi",
+                "Genre": "history",
+                "Pages": "198"
+            },
+            {
+                "Title": "We the Living",
+                "Author": "Rand, Ayn",
+                "Genre": "fiction",
+                "Pages": "178"
+            },
+            {
+                "Title": "Final Crisis",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "257"
+            },
+            {
+                "Title": "Mossad",
+                "Author": "Baz-Zohar, Michael",
+                "Genre": "history",
+                "Pages": "236"
+            },
+            {
+                "Title": "Ropemaker, The",
+                "Author": "Dickinson, Peter",
+                "Genre": "fiction",
+                "Pages": "196"
+            }
+        ]
+    },
+    {
+        "name": "Dyer Bartlett",
+        "gender": "male",
+        "address": "880 Meadow Street, Seymour, Puerto Rico, 7921",
+        "age": 33,
+        "books": [
+            {
+                "Title": "Beautiful and the Damned, The",
+                "Author": "Deb, Siddhartha",
+                "Genre": "nonfiction",
+                "Pages": "198"
+            },
+            {
+                "Title": "Soft Computing & Intelligent Systems",
+                "Author": "Gupta, Madan",
+                "Genre": "data_science",
+                "Pages": "242"
+            },
+            {
+                "Title": "World's Greatest Trials, The",
+                "Author": "",
+                "Genre": "history",
+                "Pages": "210"
+            },
+            {
+                "Title": "Artist and the Mathematician, The",
+                "Author": "Aczel, Amir",
+                "Genre": "science",
+                "Pages": "186"
+            },
+            {
+                "Title": "Killing Joke, The",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "283"
+            },
+            {
+                "Title": "Jim Corbett Omnibus",
+                "Author": "Corbett, Jim",
+                "Genre": "nonfiction",
+                "Pages": "223"
+            },
+            {
+                "Title": "Angels & Demons",
+                "Author": "Brown, Dan",
+                "Genre": "fiction",
+                "Pages": "170"
+            }
+        ]
+    },
+    {
+        "name": "Tyler Dotson",
+        "gender": "male",
+        "address": "220 Herkimer Place, Turpin, Oklahoma, 4468",
+        "age": 20,
+        "books": [
+            {
+                "Title": "Outsider, The",
+                "Author": "Camus, Albert",
+                "Genre": "fiction",
+                "Pages": "198"
+            },
+            {
+                "Title": "Textbook of Economic Theory",
+                "Author": "Stonier, Alfred",
+                "Genre": "economics",
+                "Pages": "242"
+            },
+            {
+                "Title": "Great Indian Novel, The",
+                "Author": "Tharoor, Shashi",
+                "Genre": "fiction",
+                "Pages": "198"
+            },
+            {
+                "Title": "History of Western Philosophy",
+                "Author": "Russell, Bertrand",
+                "Genre": "philosophy",
+                "Pages": "213"
+            },
+            {
+                "Title": "Flashpoint",
+                "Author": "",
+                "Genre": "comic",
+                "Pages": "265"
+            },
+            {
+                "Title": "20000 Leagues Under the Sea",
+                "Author": "Verne, Jules",
+                "Genre": "fiction",
+                "Pages": "190"
+            },
+            {
+                "Title": "Judge, The",
+                "Author": "",
+                "Genre": "fiction",
+                "Pages": "170"
+            }
+        ]
+    }
+]

--- a/test-data.py
+++ b/test-data.py
@@ -1,0 +1,37 @@
+import csv
+import os.path
+import json
+
+PATH_DIR = os.path.dirname(__file__)
+
+PATH_BOOK_CSV = os.path.join(PATH_DIR, "books.csv")
+PATH_USER_JSON = os.path.join(PATH_DIR, "users.json")
+PATH_RESULT_JSON = os.path.join(PATH_DIR, "result.json")
+
+bc = open(PATH_BOOK_CSV, "r", newline="")
+books_reader = csv.reader(bc)
+header = next(books_reader)
+header.remove("Publisher")
+
+users = []
+with open(PATH_USER_JSON, "r") as f:
+    users_load = json.load(f)
+    users = [ dict(
+        name = u["name"],
+        gender = u["gender"],
+        address = u["address"],
+        age = u["age"],
+        books = []
+    ) for u in users_load]
+
+user_index = 0
+for book in books_reader:
+    users[user_index]["books"].append(dict(zip(header, book)))
+    user_index += 1
+    if user_index >= len(users):
+        user_index = 0
+
+bc.close()
+
+with open(PATH_RESULT_JSON, "w") as f:
+    json.dump(users, f, indent=4)


### PR DESCRIPTION
Добавлен файл test-data.py в котором реализовано: открытие исходных файлов (books.csv, users.json), формирование из данных полученных из файлов результирующих данных, вида - данные о пользователе и принадлежащих ему книгах, и запись в результирующий файл result.json. 